### PR TITLE
Improve syntax highlighting based on purescript's grammar

### DIFF
--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -108,8 +108,8 @@ syn region purescriptBlockComment start="{-" end="-}" fold
   \ contains=purescriptBlockComment
 
 highlight def link purescriptModuleKeyword purescriptKeyword
-highlight def link purescriptModuleName purescriptInclude
-highlight def link purescriptModuleParams Delimiter
+highlight def link purescriptModuleName Include
+highlight def link purescriptModuleParams purescriptDelimiter
 highlight def link purescriptImportKeyword purescriptKeyword
 highlight def link purescriptAsKeyword purescriptKeyword
 highlight def link purescriptHidingKeyword purescriptKeyword
@@ -120,8 +120,8 @@ highlight def link purescriptInfix PreProc
 highlight def link purescriptNumber Number
 highlight def link purescriptFloat Float
 
+highlight def link purescriptBlockDelimiter purescriptDelimiter
 highlight def link purescriptDelimiter Delimiter
-highlight def link purescriptBlockDelimiter Delimiter
 
 highlight def link purescriptOperatorType purescriptOperator
 highlight def link purescriptOperatorTypeSig purescriptOperatorType
@@ -143,10 +143,9 @@ highlight def link purescriptMultilineString String
 highlight def link purescriptLineComment purescriptComment
 highlight def link purescriptBlockComment purescriptComment
 
+highlight def link purescriptStructure purescriptKeyword
 highlight def link purescriptKeyword Keyword
-highlight def link purescriptInclude Include
 highlight def link purescriptStatement Statement
-highlight def link purescriptStructure Structure
 highlight def link purescriptOperator Operator
 highlight def link purescriptIdentifier Identifier
 highlight def link purescriptFunction Function

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -95,6 +95,9 @@ syn region purescriptClass start="^\<class\>" end="where"me=e-5
 syn region purescriptInstance start="^instance\>" end="where"me=e-5
   \ contains=purescriptStructure,purescriptIdentifier,purescriptOperatorType,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptWhere
+syn region purescriptInstance start="^instance\>" end="$"
+  \ contains=purescriptStructure,purescriptIdentifier,purescriptOperatorType,purescriptType,purescriptTypeVar
+  \ nextgroup=purescriptWhere
 syn region purescriptDeriveInstance start="^derive\s\+instance\>" end="$"
   \ contains=purescriptStructure,purescriptInstanceKeyword,purescriptIdentifier,purescriptOperatorType,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptWhere

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -21,6 +21,7 @@ syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[
   \ contains=purescriptType,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperatorType,purescriptOperatorTypeSig
 
 syn match purescriptIdentifier "\<[_a-z]\w*\>" contained
+  \ nextgroup=purescriptIdentifier skipwhite
 syn region purescriptFunctionBody start="^\z(\s*\)[_a-z]\w*\s*.\+\(=\|$\)" end="^\z1\S"me=e-1 fold
   \ contains=purescriptNumber,purescriptFloat,purescriptConstructor,purescriptOperator,purescriptOperatorFunction,purescriptDelimiter,purescriptBlockDelimiter,purescriptConditional,purescriptStatement,purescriptWhere,purescriptChar,purescriptBacktick,purescriptString,purescriptMultilineString,purescriptLineComment,purescriptBlockComment,purescriptFunctionDecl,purescriptFunctionBody
 syn region purescriptFunctionDecl start="^\z(\s*\)\(foreign import\s\+\)\?[_a-z]\w*\s*\(::\|∷\)" end="^\z1\S"me=e-1 keepend

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -15,9 +15,9 @@ syn match purescriptTypeVar "\<[_a-z]\(\w\|\'\)*\>" contained
 syn region purescriptTypeExport matchgroup=purescriptType start="\<[A-Z]\(\S\&[^,.]\)*\>("rs=e-1 matchgroup=purescriptBlockDelimiter end=")" contained extend
   \ contains=purescriptConstructor,purescriptBlockDelimiter
 
-syn match purescriptConstructor "\<[A-Z]\w*\>"
+syn match purescriptConstructor "\<[A-Z]\w*\>" contained
   \ nextgroup=purescriptIdentifier skipwhite
-syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[A-Z]\w*\>" end="\(|\|$\)"me=e-1,re=e-1 contained
+syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[A-Z]\w*\>" end="\(|\|$\)"me=e-1,re=e-1
   \ contains=purescriptType,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperatorType,purescriptOperatorTypeSig
 
 syn match purescriptIdentifier "\<[_a-z]\(\w\|\'\)*\>" contained

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -10,7 +10,7 @@ if exists("b:current_syntax")
 endif
 
 syn match purescriptType "\<[A-Z]\w*\>"
-  \ nextgroup=purescriptType,purescriptTypeVar,purescriptOperatorTypeSig,purescriptDelimiter,purescriptBlockDelimiter skipwhite
+  \ nextgroup=purescriptType,purescriptTypeVar,purescriptOperatorTypeSig,purescriptDelimiter,purescriptBlockDelimiter,purescriptWhere skipwhite
 syn match purescriptTypeVar "\<[_a-z]\(\w\|\'\)*\>" contained
 syn region purescriptTypeExport matchgroup=purescriptType start="\<[A-Z]\(\S\&[^,.]\)*\>("rs=e-1 matchgroup=purescriptBlockDelimiter end=")" contained extend
   \ contains=purescriptConstructor,purescriptBlockDelimiter
@@ -20,7 +20,7 @@ syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[
   \ contains=purescriptType,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperatorType,purescriptOperatorTypeSig
 
 syn region purescriptFunctionBody excludenl start="^\z(\s*\)[_a-z]\(\w\|\'\)*\([^=]\{-}=\|\_.\{-}|\)" end="^\z1\?\S"me=s-1,re=s-1 fold keepend
-  \ contains=purescriptNumber,purescriptFloat,purescriptConstructor,purescriptOperator,purescriptOperatorFunction,purescriptDelimiter,purescriptBlockDelimiter,purescriptConditional,purescriptStatement,purescriptWhere,purescriptChar,purescriptBacktick,purescriptString,purescriptMultilineString,purescriptLineComment,purescriptBlockComment,purescriptFunctionDecl,purescriptFunctionBody
+  \ contains=purescriptBoolean,purescriptNumber,purescriptFloat,purescriptConstructor,purescriptOperator,purescriptOperatorFunction,purescriptDelimiter,purescriptBlockDelimiter,purescriptConditional,purescriptStatement,purescriptWhere,purescriptChar,purescriptBacktick,purescriptString,purescriptMultilineString,purescriptLineComment,purescriptBlockComment,purescriptFunctionDecl,purescriptFunctionBody
 syn region purescriptFunctionDecl start="^\z(\s*\)\(foreign import\s\+\)\?[_a-z]\(\w\|\'\)*\s*\(::\|∷\)" end="^\z1\?\S"me=s-1,re=s-1 keepend
   \ contains=purescriptFunctionDeclStart,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptBlockDelimiter,purescriptDelimiter,purescriptForall
 syn match purescriptFunctionDeclStart "\(foreign import\s\+\)\?[_a-z]\(\w\|\'\)*\s*\(::\|∷\)" contained
@@ -59,6 +59,7 @@ syn keyword purescriptWhere where
 syn keyword purescriptStructure foreign data newtype type class instance derive contained
 syn keyword purescriptInfix infix infixl infixr
 
+syn keyword purescriptBoolean true false
 syn match purescriptNumber "[0-9]\+\|0[xX][0-9a-fA-F]\+\|0[oO][0-7]"
 syn match purescriptFloat "[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\="
 
@@ -86,18 +87,10 @@ syn region purescriptTypeAlias start="^type" end="="he=e-1
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptForall,purescriptType,purescriptTypeVar skipwhite skipnl
 
-syn region purescriptClass start="^\<class\>" end="where"me=e-5
-  \ contains=purescriptStructure,purescriptType,purescriptTypeVar
-  \ nextgroup=purescriptWhere
-syn region purescriptInstance start="^instance\>" end="where"me=e-5
-  \ contains=purescriptStructure,purescriptOperatorType,purescriptType,purescriptTypeVar
-  \ nextgroup=purescriptWhere
-syn region purescriptInstance start="^instance\>" end="$"
-  \ contains=purescriptStructure,purescriptOperatorType,purescriptType,purescriptTypeVar
-  \ nextgroup=purescriptWhere
-syn region purescriptDeriveInstance start="^derive\s\+instance\>" end="$"
-  \ contains=purescriptStructure,purescriptInstanceKeyword,purescriptOperatorType,purescriptType,purescriptTypeVar
-  \ nextgroup=purescriptWhere
+syn region purescriptClass start="^class\>" end="$"
+  \ contains=purescriptStructure,purescriptType,purescriptTypeVar,purescriptWhere
+syn region purescriptInstance start="^\(derive\s\+\)\=instance\>" end="$"
+  \ contains=purescriptStructure,purescriptOperatorType,purescriptType,purescriptTypeVar,purescriptWhere
 
 syn match purescriptChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
 syn match purescriptBacktick "`[A-Za-z][A-Za-z0-9_]*`"
@@ -109,6 +102,7 @@ syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
 syn region purescriptBlockComment start="{-" end="-}" fold
   \ contains=purescriptBlockComment
 
+" highlight links
 highlight def link purescriptModuleKeyword purescriptKeyword
 highlight def link purescriptModuleName Include
 highlight def link purescriptModuleParams purescriptDelimiter
@@ -118,21 +112,23 @@ highlight def link purescriptHidingKeyword purescriptKeyword
 
 highlight def link purescriptConditional Conditional
 highlight def link purescriptWhere purescriptKeyword
-highlight def link purescriptInfix PreProc
+highlight def link purescriptInfix purescriptKeyword
+
+highlight def link purescriptBoolean Boolean
 highlight def link purescriptNumber Number
 highlight def link purescriptFloat Float
 
 highlight def link purescriptBlockDelimiter purescriptDelimiter
 highlight def link purescriptDelimiter Delimiter
 
-highlight def link purescriptOperatorType purescriptOperator
 highlight def link purescriptOperatorTypeSig purescriptOperatorType
 highlight def link purescriptOperatorFunction purescriptOperatorType
+highlight def link purescriptOperatorType purescriptOperator
 
 highlight def link purescriptFunctionName purescriptFunction
 
-highlight def link purescriptConstructor purescriptFunction
 highlight def link purescriptConstructorDecl purescriptConstructor
+highlight def link purescriptConstructor purescriptFunction
 
 highlight def link purescriptTypeVar Identifier
 highlight def link purescriptForall purescriptStatement
@@ -145,6 +141,7 @@ highlight def link purescriptMultilineString String
 highlight def link purescriptLineComment purescriptComment
 highlight def link purescriptBlockComment purescriptComment
 
+" purescript general highlights
 highlight def link purescriptStructure purescriptKeyword
 highlight def link purescriptKeyword Keyword
 highlight def link purescriptStatement Statement

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -16,12 +16,9 @@ syn region purescriptTypeExport matchgroup=purescriptType start="\<[A-Z]\(\S\&[^
   \ contains=purescriptConstructor,purescriptBlockDelimiter
 
 syn match purescriptConstructor "\<[A-Z]\w*\>" contained
-  \ nextgroup=purescriptIdentifier skipwhite
 syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[A-Z]\w*\>" end="\(|\|$\)"me=e-1,re=e-1
   \ contains=purescriptType,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperatorType,purescriptOperatorTypeSig
 
-syn match purescriptIdentifier "\<[_a-z]\(\w\|\'\)*\>" contained
-  \ nextgroup=purescriptIdentifier skipwhite
 syn region purescriptFunctionBody excludenl start="^\z(\s*\)[_a-z]\(\w\|\'\)*\([^=]\{-}=\|\_.\{-}|\)" end="^\z1\?\S"me=s-1,re=s-1 fold keepend
   \ contains=purescriptNumber,purescriptFloat,purescriptConstructor,purescriptOperator,purescriptOperatorFunction,purescriptDelimiter,purescriptBlockDelimiter,purescriptConditional,purescriptStatement,purescriptWhere,purescriptChar,purescriptBacktick,purescriptString,purescriptMultilineString,purescriptLineComment,purescriptBlockComment,purescriptFunctionDecl,purescriptFunctionBody
 syn region purescriptFunctionDecl start="^\z(\s*\)\(foreign import\s\+\)\?[_a-z]\(\w\|\'\)*\s*\(::\|∷\)" end="^\z1\?\S"me=s-1,re=s-1 keepend
@@ -93,13 +90,13 @@ syn region purescriptClass start="^\<class\>" end="where"me=e-5
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptWhere
 syn region purescriptInstance start="^instance\>" end="where"me=e-5
-  \ contains=purescriptStructure,purescriptIdentifier,purescriptOperatorType,purescriptType,purescriptTypeVar
+  \ contains=purescriptStructure,purescriptOperatorType,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptWhere
 syn region purescriptInstance start="^instance\>" end="$"
-  \ contains=purescriptStructure,purescriptIdentifier,purescriptOperatorType,purescriptType,purescriptTypeVar
+  \ contains=purescriptStructure,purescriptOperatorType,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptWhere
 syn region purescriptDeriveInstance start="^derive\s\+instance\>" end="$"
-  \ contains=purescriptStructure,purescriptInstanceKeyword,purescriptIdentifier,purescriptOperatorType,purescriptType,purescriptTypeVar
+  \ contains=purescriptStructure,purescriptInstanceKeyword,purescriptOperatorType,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptWhere
 
 syn match purescriptChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
@@ -137,7 +134,7 @@ highlight def link purescriptFunctionName purescriptFunction
 highlight def link purescriptConstructor purescriptFunction
 highlight def link purescriptConstructorDecl purescriptConstructor
 
-highlight def link purescriptTypeVar purescriptIdentifier
+highlight def link purescriptTypeVar Identifier
 highlight def link purescriptForall purescriptStatement
 
 highlight def link purescriptChar String
@@ -152,7 +149,6 @@ highlight def link purescriptStructure purescriptKeyword
 highlight def link purescriptKeyword Keyword
 highlight def link purescriptStatement Statement
 highlight def link purescriptOperator Operator
-highlight def link purescriptIdentifier Identifier
 highlight def link purescriptFunction Function
 highlight def link purescriptType Type
 highlight def link purescriptComment Comment

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -65,11 +65,11 @@ syn keyword purescriptInfix infix infixl infixr
 syn match purescriptNumber "[0-9]\+\|0[xX][0-9a-fA-F]\+\|0[oO][0-7]"
 syn match purescriptFloat "[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\="
 
+syn match purescriptOperator "\([-!#$%&\*\+/<=>\?@\\^|~:]\|\<_\>\)"
 syn match purescriptOperatorType "\(::\|∷\)" contained
   \ nextgroup=purescriptForall,purescriptType skipwhite skipempty
 syn match purescriptOperatorTypeSig "\(->\|<-\|=>\|<=\|::\|[∷∀→←⇒⇐]\)" contained
   \ nextgroup=purescriptType skipwhite skipempty
-syn match purescriptOperator "\([-!#$%&\*\+/<=>\?@\\^|~:]\|\<_\>\)"
 syn match purescriptOperatorFunction "\(->\|<-\|[→←]\)" contained
 
 syn match purescriptDelimiter "[,;|]"
@@ -80,6 +80,8 @@ syn region purescriptDataType start="^data" end="="me=e-1,re=e-1
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
 syn region purescriptDataConstructors start="" end="^\S"me=e-1 contained keepend
   \ contains=purescriptForall,purescriptConstructorDecl,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperator,purescriptOperatorType,purescriptOperatorTypeSig
+syn region purescriptForeignData start="^foreign\s\+import\s\+data\>" end="$"
+  \ contains=purescriptImportKeyword,purescriptStructure,purescriptType,purescriptOperatorType,purescriptOperator,purescriptOperatorTypeSig
 syn region purescriptNewtype start="^newtype" end="="he=e-1 keepend
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptForall,purescriptConstructorDecl,purescriptTypeVar skipwhite skipnl

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -9,44 +9,147 @@ if exists("b:current_syntax")
   finish
 endif
 
-syn keyword purescriptModule module
-syn keyword purescriptImport foreign import hiding
-syn region purescriptQualifiedImport start="\<qualified\>" contains=purescriptType,purescriptDot end="\<as\>"
-syn keyword purescriptStructure data newtype type class instance derive where
-syn keyword purescriptStatement forall do case of let in
+syn match purescriptType "\<[A-Z]\w*\>"
+  \ nextgroup=purescriptType,purescriptTypeVar,purescriptOperatorTypeSig,purescriptDelimiter,purescriptBlockDelimiter skipwhite
+syn match purescriptTypeVar "\<[_a-z]\w*\>" contained
+syn region purescriptTypeExport matchgroup=purescriptType start="\<[A-Z]\(\S\&[^,.]\)*\>("rs=e-1 matchgroup=purescriptBlockDelimiter end=")" contained extend
+  \ contains=purescriptConstructor,purescriptBlockDelimiter
+
+syn match purescriptConstructor "\<[A-Z]\w*\>"
+  \ nextgroup=purescriptIdentifier skipwhite
+syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[A-Z]\w*\>" end="\(|\|$\)"me=e-1 contained
+  \ contains=purescriptType,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperatorType,purescriptOperatorTypeSig
+
+syn match purescriptIdentifier "\<[_a-z]\w*\>" contained
+syn region purescriptFunctionBody start="^\z(\s*\)[_a-z]\w*\s*.\+\(=\|$\)" end="^\z1\S"me=e-1 fold
+  \ contains=purescriptNumber,purescriptFloat,purescriptConstructor,purescriptOperator,purescriptOperatorFunction,purescriptDelimiter,purescriptBlockDelimiter,purescriptConditional,purescriptStatement,purescriptWhere,purescriptChar,purescriptBacktick,purescriptString,purescriptMultilineString,purescriptLineComment,purescriptBlockComment,purescriptFunctionDecl,purescriptFunctionBody
+syn region purescriptFunctionDecl start="^\z(\s*\)\(foreign import\s\+\)\?[_a-z]\w*\s*\(::\|∷\)" end="^\z1\S"me=e-1 keepend
+  \ contains=purescriptFunctionDeclStart,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptBlockDelimiter,purescriptDelimiter,purescriptForall
+syn match purescriptFunctionDeclStart "^\(\s*\)\(foreign import\s\+\)\?[_a-z]\w*\s*\(::\|∷\)" contained
+  \ contains=purescriptImportKeyword,purescriptFunctionName,purescriptOperatorType
+syn match purescriptFunctionName "\<[_a-z]\w*\>" contained
+syn match purescriptFunctionName "(\(\W\&[^(),\"]\)\+)" contained extend
+syn match purescriptForall "\(forall\|∀\)"
+  \ nextgroup=purescriptTypeVar skipwhite
+
+syn match purescriptModule "^\<module\>\s\+\<\(\w\+\.\?\)*\>"
+  \ contains=purescriptModuleKeyword,purescriptModuleName
+  \ nextgroup=purescriptModuleParams skipwhite skipempty
+syn keyword purescriptModuleKeyword module contained
+syn match purescriptModuleName "\(\w\+\.\?\)*" contained excludenl
+syn region purescriptModuleParams start="(" end=")" fold contained keepend
+  \ contains=purescriptBlockComment,purescriptLineComment,purescriptDelimiter,purescriptType,purescriptTypeExport,purescriptFunctionName
+  \ nextgroup=purescriptImportParams skipwhite
+
+syn match purescriptImport "\<import\>\s\+\(qualified\s\+\)\?\(\<\(\w\|\.\)*\>\)"
+  \ contains=purescriptImportKeyword,purescriptModuleName
+  \ nextgroup=purescriptModuleParams,purescriptImportParams skipwhite
+syn match purescriptImportParams "as\s\+\(\w\+\)" contained
+  \ contains=purescriptModuleName,purescriptAsKeyword
+  \ nextgroup=purescriptModuleParams,purescriptImportParams skipwhite
+syn match purescriptImportParams "hiding" contained
+  \ contains=purescriptHidingKeyword
+  \ nextgroup=purescriptModuleParams,purescriptImportParams skipwhite
+
+syn keyword purescriptImportKeyword foreign import qualified contained
+syn keyword purescriptAsKeyword as contained
+syn keyword purescriptHidingKeyword hiding contained
+
 syn keyword purescriptConditional if then else
-syn match purescriptNumber "\<[0-9]\+\>\|\<0[xX][0-9a-fA-F]\+\>\|\<0[oO][0-7]\+\>"
-syn match purescriptFloat "\<[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\=\>"
-syn match purescriptDelimiter  "[(),;[\]{}]"
+syn keyword purescriptStatement do case of let in
+syn keyword purescriptWhere where
+syn keyword purescriptStructure foreign data newtype type class instance derive contained
 syn keyword purescriptInfix infix infixl infixr
-syn match purescriptOperators "\([-!#$%&\*\+/<=>\?@\\^|~:]\|\<_\>\)"
-syn match purescriptDot "\."
-syn match purescriptType "\<\([A-Z][a-zA-Z0-9_]*\|_|_\)\>"
-syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
+
+syn match purescriptNumber "[0-9]\+\|0[xX][0-9a-fA-F]\+\|0[oO][0-7]"
+syn match purescriptFloat "[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\="
+
+syn match purescriptOperatorType "\(::\|∷\)" contained
+  \ nextgroup=purescriptForall,purescriptType skipwhite skipempty
+syn match purescriptOperatorTypeSig "\(->\|<-\|=>\|<=\|::\|[∷∀→←⇒⇐]\)" contained
+  \ nextgroup=purescriptType skipwhite skipempty
+syn match purescriptOperator "\([-!#$%&\*\+/<=>\?@\\^|~:]\|\<_\>\)"
+syn match purescriptOperatorFunction "\(->\|<-\|[→←]\)" contained
+
+syn match purescriptDelimiter "[,;|]"
+syn match purescriptBlockDelimiter "[()[\]{}]"
+
+syn region purescriptDataType start="^data" end="="me=e-1,re=e-1
+  \ nextgroup=purescriptDataConstructors skipwhite skipnl
+  \ contains=purescriptStructure,purescriptType,purescriptTypeVar
+syn region purescriptDataConstructors start="" end="^\S"me=e-1 contained keepend
+  \ contains=purescriptForall,purescriptConstructorDecl,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperator,purescriptOperatorType,purescriptOperatorTypeSig
+syn region purescriptNewtype start="^newtype" end="="he=e-1 keepend
+  \ contains=purescriptStructure,purescriptType,purescriptTypeVar
+  \ nextgroup=purescriptForall,purescriptConstructorDecl,purescriptTypeVar skipwhite skipnl
+syn region purescriptTypeAlias start="^type" end="="he=e-1 keepend
+  \ contains=purescriptStructure,purescriptType,purescriptTypeVar
+  \ nextgroup=purescriptForall,purescriptType,purescriptTypeVar skipwhite skipnl
+
+syn region purescriptClass start="^\<class\>" end="where"me=e-5
+  \ contains=purescriptStructure,purescriptType,purescriptTypeVar
+  \ nextgroup=purescriptWhere
+syn region purescriptInstance start="^instance\>" end="where"me=e-5
+  \ contains=purescriptStructure,purescriptIdentifier,purescriptOperatorType,purescriptType,purescriptTypeVar
+  \ nextgroup=purescriptWhere
+syn region purescriptDeriveInstance start="^derive\s\+instance\>" end="$"
+  \ contains=purescriptStructure,purescriptInstanceKeyword,purescriptIdentifier,purescriptOperatorType,purescriptType,purescriptTypeVar
+  \ nextgroup=purescriptWhere
+
 syn match purescriptChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
 syn match purescriptBacktick "`[A-Za-z][A-Za-z0-9_]*`"
-syn region purescriptString start=+"+ skip=+\\\\\|\\"+ end=+"+
-syn region purescriptMultilineString start=+"""+ end=+"""+
-syn region purescriptBlockComment start="{-" end="-}" contains=purescriptBlockComment
 
-highlight def link purescriptImport Structure
-highlight def link purescriptQualifiedImport Structure
-highlight def link purescriptModule Structure
-highlight def link purescriptStructure Structure
-highlight def link purescriptStatement Statement
+syn region purescriptString start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn region purescriptMultilineString start=+"""+ end=+"""+ fold
+
+syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$"
+syn region purescriptBlockComment start="{-" end="-}" fold
+  \ contains=purescriptBlockComment
+
+highlight def link purescriptModuleKeyword purescriptKeyword
+highlight def link purescriptModuleName purescriptInclude
+highlight def link purescriptModuleParams Delimiter
+highlight def link purescriptImportKeyword purescriptKeyword
+highlight def link purescriptAsKeyword purescriptKeyword
+highlight def link purescriptHidingKeyword purescriptKeyword
+
 highlight def link purescriptConditional Conditional
+highlight def link purescriptWhere purescriptKeyword
+highlight def link purescriptInfix PreProc
 highlight def link purescriptNumber Number
 highlight def link purescriptFloat Float
+
 highlight def link purescriptDelimiter Delimiter
-highlight def link purescriptInfix PreProc
-highlight def link purescriptOperators Operator
-highlight def link purescriptDot Operator
-highlight def link purescriptType Include
-highlight def link purescriptLineComment Comment
-highlight def link purescriptBlockComment Comment
+highlight def link purescriptBlockDelimiter Delimiter
+
+highlight def link purescriptOperatorType purescriptOperator
+highlight def link purescriptOperatorTypeSig purescriptOperatorType
+highlight def link purescriptOperatorFunction purescriptOperatorType
+
+highlight def link purescriptFunctionName purescriptFunction
+
+highlight def link purescriptConstructor purescriptFunction
+highlight def link purescriptConstructorDecl purescriptConstructor
+
+highlight def link purescriptTypeVar purescriptIdentifier
+highlight def link purescriptForall purescriptStatement
+
+highlight def link purescriptChar String
+highlight def link purescriptBacktick purescriptOperator
 highlight def link purescriptString String
 highlight def link purescriptMultilineString String
-highlight def link purescriptChar String
-highlight def link purescriptBacktick Operator
+
+highlight def link purescriptLineComment purescriptComment
+highlight def link purescriptBlockComment purescriptComment
+
+highlight def link purescriptKeyword Keyword
+highlight def link purescriptInclude Include
+highlight def link purescriptStatement Statement
+highlight def link purescriptStructure Structure
+highlight def link purescriptOperator Operator
+highlight def link purescriptIdentifier Identifier
+highlight def link purescriptFunction Function
+highlight def link purescriptType Type
+highlight def link purescriptComment Comment
 
 let b:current_syntax = "purescript"

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -35,7 +35,7 @@ syn match purescriptForall "\(forall\|∀\)"
 
 syn match purescriptModule "^\<module\>\s\+\<\(\w\+\.\?\)*\>"
   \ contains=purescriptModuleKeyword,purescriptModuleName
-  \ nextgroup=purescriptModuleParams skipwhite skipempty
+  \ nextgroup=purescriptModuleParams skipwhite skipnl skipempty
 syn keyword purescriptModuleKeyword module contained
 syn match purescriptModuleName "\(\w\+\.\?\)*" contained excludenl
 syn region purescriptModuleParams start="(" end=")" fold contained keepend
@@ -67,9 +67,9 @@ syn match purescriptFloat "[0-9]\+\.[0-9]\+\([eE][-+]\=[0-9]\+\)\="
 
 syn match purescriptOperator "\([-!#$%&\*\+/<=>\?@\\^|~:]\|\<_\>\)"
 syn match purescriptOperatorType "\(::\|∷\)" contained
-  \ nextgroup=purescriptForall,purescriptType skipwhite skipempty
+  \ nextgroup=purescriptForall,purescriptType skipwhite skipnl skipempty
 syn match purescriptOperatorTypeSig "\(->\|<-\|=>\|<=\|::\|[∷∀→←⇒⇐]\)" contained
-  \ nextgroup=purescriptType skipwhite skipempty
+  \ nextgroup=purescriptType skipwhite skipnl skipempty
 syn match purescriptOperatorFunction "\(->\|<-\|[→←]\)" contained
 
 syn match purescriptDelimiter "[,;|]"

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -11,24 +11,24 @@ endif
 
 syn match purescriptType "\<[A-Z]\w*\>"
   \ nextgroup=purescriptType,purescriptTypeVar,purescriptOperatorTypeSig,purescriptDelimiter,purescriptBlockDelimiter skipwhite
-syn match purescriptTypeVar "\<[_a-z]\w*\>" contained
+syn match purescriptTypeVar "\<[_a-z]\(\w\|\'\)*\>" contained
 syn region purescriptTypeExport matchgroup=purescriptType start="\<[A-Z]\(\S\&[^,.]\)*\>("rs=e-1 matchgroup=purescriptBlockDelimiter end=")" contained extend
   \ contains=purescriptConstructor,purescriptBlockDelimiter
 
 syn match purescriptConstructor "\<[A-Z]\w*\>"
   \ nextgroup=purescriptIdentifier skipwhite
-syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[A-Z]\w*\>" end="\(|\|$\)"me=e-1 contained
+syn region purescriptConstructorDecl matchgroup=purescriptConstructor start="\<[A-Z]\w*\>" end="\(|\|$\)"me=e-1,re=e-1 contained
   \ contains=purescriptType,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperatorType,purescriptOperatorTypeSig
 
-syn match purescriptIdentifier "\<[_a-z]\w*\>" contained
+syn match purescriptIdentifier "\<[_a-z]\(\w\|\'\)*\>" contained
   \ nextgroup=purescriptIdentifier skipwhite
-syn region purescriptFunctionBody start="^\z(\s*\)[_a-z]\w*\s*.\+\(=\|$\)" end="^\z1\S"me=e-1 fold
+syn region purescriptFunctionBody excludenl start="^\z(\s*\)[_a-z]\(\w\|\'\)*\([^=]\{-}=\|\_.\{-}|\)" end="^\z1\?\S"me=s-1,re=s-1 fold keepend
   \ contains=purescriptNumber,purescriptFloat,purescriptConstructor,purescriptOperator,purescriptOperatorFunction,purescriptDelimiter,purescriptBlockDelimiter,purescriptConditional,purescriptStatement,purescriptWhere,purescriptChar,purescriptBacktick,purescriptString,purescriptMultilineString,purescriptLineComment,purescriptBlockComment,purescriptFunctionDecl,purescriptFunctionBody
-syn region purescriptFunctionDecl start="^\z(\s*\)\(foreign import\s\+\)\?[_a-z]\w*\s*\(::\|∷\)" end="^\z1\S"me=e-1 keepend
+syn region purescriptFunctionDecl start="^\z(\s*\)\(foreign import\s\+\)\?[_a-z]\(\w\|\'\)*\s*\(::\|∷\)" end="^\z1\?\S"me=s-1,re=s-1 keepend
   \ contains=purescriptFunctionDeclStart,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptBlockDelimiter,purescriptDelimiter,purescriptForall
-syn match purescriptFunctionDeclStart "^\(\s*\)\(foreign import\s\+\)\?[_a-z]\w*\s*\(::\|∷\)" contained
+syn match purescriptFunctionDeclStart "\(foreign import\s\+\)\?[_a-z]\(\w\|\'\)*\s*\(::\|∷\)" contained
   \ contains=purescriptImportKeyword,purescriptFunctionName,purescriptOperatorType
-syn match purescriptFunctionName "\<[_a-z]\w*\>" contained
+syn match purescriptFunctionName "\<[_a-z]\(\w\|\'\)*\>" contained
 syn match purescriptFunctionName "(\(\W\&[^(),\"]\)\+)" contained extend
 syn match purescriptForall "\(forall\|∀\)"
   \ nextgroup=purescriptTypeVar skipwhite
@@ -82,10 +82,10 @@ syn region purescriptDataConstructors start="" end="^\S"me=e-1 contained keepend
   \ contains=purescriptForall,purescriptConstructorDecl,purescriptTypeVar,purescriptDelimiter,purescriptBlockDelimiter,purescriptOperator,purescriptOperatorType,purescriptOperatorTypeSig
 syn region purescriptForeignData start="^foreign\s\+import\s\+data\>" end="$"
   \ contains=purescriptImportKeyword,purescriptStructure,purescriptType,purescriptOperatorType,purescriptOperator,purescriptOperatorTypeSig
-syn region purescriptNewtype start="^newtype" end="="he=e-1 keepend
+syn region purescriptNewtype start="^newtype" end="="he=e-1
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptForall,purescriptConstructorDecl,purescriptTypeVar skipwhite skipnl
-syn region purescriptTypeAlias start="^type" end="="he=e-1 keepend
+syn region purescriptTypeAlias start="^type" end="="he=e-1
   \ contains=purescriptStructure,purescriptType,purescriptTypeVar
   \ nextgroup=purescriptForall,purescriptType,purescriptTypeVar skipwhite skipnl
 


### PR DESCRIPTION
The previous version of purescript's syntax highlighting for vim didn't highlight correctly all the elements, missing key pieces such as: constructors being highlighted the same as types, function names on declarations not highlighted, type variables or module exports/imports.

This pull request is an attempt to fix some inconsistencies by replicating purescript's syntax grammar, thus enabling the coder to quickly identify all syntactic elements of purescript.

![Preview of the improvements using the color scheme Molokai](https://pbs.twimg.com/media/CqufibJWYAAw9-M.jpg:large)