### PR TITLE
indentation: fix some issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,32 +31,44 @@ Be sure that the following lines are in your
 
 To configure indentation in `purescript-vim` you can use the following variables:
 
-* `let g:purescript_indent_if = 3`
+* `let purescript_indent_if = 3`
 
         if bool
         >>>then ...
         >>>else ...
   
-* `let g:purescript_indent_case = 5`
+* `let purescript_indent_case = 5`
 
         case xs of
         >>>>>[]     -> ...
         >>>>>(y:ys) -> ...
     
-* `let g:purescript_indent_let = 4`
+* `let purescript_indent_let = 4`
 
         let x = 0 in
         >>>>x
   
-* `let g:purescript_indent_where = 6`
+* `let purescript_indent_where = 6`
 
         where f :: Int -> Int
         >>>>>>f x = x
   
-* `let g:purescript_indent_do = 3`
+* `let purescript_indent_do = 3`
         
         do x <- a
         >>>y <- b
+
+* `let purescript_indent_in = 1`
+
+	let x = 0
+	>in x
+
+* `let purescript_indent_dot = v:true`
+
+	unsnoc
+	  :: forall a
+	  >. List a
+	  -> Maybe (List a, a)
 
 
 [Purescript]: http://www.purescript.org

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -92,7 +92,7 @@ function! GetPurescriptIndent()
     return s
   endif
 
-  if prevline =~ '^\S.*::' && line !~ '^\s*\(\.\|->\|=>\)'
+  if prevline =~ '^\S.*::' && line !~ '^\s*\(\.\|->\|=>\)' && !~ '^instance'
     " f :: String
     "	-> String
     return 0

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -92,6 +92,13 @@ function! GetPurescriptIndent()
     return s
   endif
 
+  " todo: find a better pattern '\<|\>' does not work.
+  let s = match(prevline, '[[:alnum:][:blank:]]\@<=|[[:alnum:][:blank:]$]')
+  if s >= 0
+    " ident pattern quards
+    return s
+  endif
+
   if prevline =~ '^\S.*::' && line !~ '^\s*\(\.\|->\|=>\)' && !~ '^instance'
     " f :: String
     "	-> String

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -152,6 +152,7 @@ function! GetPurescriptIndent()
   endif
 
   if prevline =~ '[{([][^})\]]\+$'
+    echom "return 1"
     return match(prevline, '[{([]')
   endif
 
@@ -176,6 +177,7 @@ function! GetPurescriptIndent()
   endif
 
   if prevline =~ '[{([]\s*$'
+    echom "return 2"
     return match(prevline, '\S') + (line !~ '^\s*[})]]' ? 0 : &shiftwidth)
   endif
 
@@ -199,7 +201,7 @@ function! GetPurescriptIndent()
     return match(prevline, '\<data\>') + &shiftwidth
   endif
 
-  if (line =~ '^\s*}\s*' && prevline !~ '^\s*;')
+  if prevline =~ '^\s*[}\]]'
     return match(prevline, '\S') - &shiftwidth
   endif
 

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -65,6 +65,7 @@ setlocal indentexpr=GetPurescriptIndent()
 setlocal indentkeys=!^F,o,O,},=where,=in,=::,=->,==>
 
 function! GetPurescriptIndent()
+  let ppline = getline(v:lnum - 2)
   let prevline = getline(v:lnum - 1)
   let line = getline(v:lnum)
   let synStackP = map(synstack(v:lnum - 1, col(".")), { key, val -> synIDattr(val, "name") })
@@ -86,7 +87,7 @@ function! GetPurescriptIndent()
     return s + g:purescript_indent_in
   endif
 
-  let s = match(prevline, '^\s*\zs\(--\|import\>\)')
+  let s = match(prevline, '^\s*\zs\(--\|import\)')
   if s >= 0
     " comments
     " imports
@@ -107,8 +108,12 @@ function! GetPurescriptIndent()
   endif
 
   if prevline =~ '^\S'
-    " starting type signature or function body on next line
+    " starting type signature, function body, data & newtype on next line
     return &shiftwidth
+  endif
+
+  if ppline =~ '^\S' && prevline =~ '^\s*$'
+    return 0
   endif
 
   if line =~ '^\s*::'

--- a/indent/purescript.vim
+++ b/indent/purescript.vim
@@ -87,12 +87,19 @@ function! GetPurescriptIndent()
 
   let s = match(prevline, '^\s*\zs\(--\|import\>\)')
   if s >= 0
+    " comments
+    " imports
     return s
+  endif
+
+  if prevline =~ '^\S.*::' && line !~ '^\s*\(\.\|->\|=>\)'
+    " f :: String
+    "	-> String
+    return 0
   endif
 
   if prevline =~ '^\S'
     " starting type signature or function body on next line
-    echom "xxx " . prevline
     return &shiftwidth
   endif
 

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -63,16 +63,17 @@ syn match purescriptImportParams "hiding" contained
   \ nextgroup=purescriptModuleParams,purescriptImportParams skipwhite
 
 " Function declaration
-syn region purescriptFunctionDecl excludenl start="^\z(\s*\)\(foreign\s\+import\_s\+\)\?[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)" end="^\z1\=\S"me=s-1,re=s-1 keepend
+syn region purescriptFunctionDecl excludenl start="^\z(\s*\)\(\(foreign\s\+import\|let\|where\)\_s\+\)\?[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)" end="^\z1\=\S"me=s-1,re=s-1 keepend
   \ contains=purescriptFunctionDeclStart,purescriptForall,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptDelimiter,@purescriptComment
-syn match purescriptFunctionDeclStart "^\s*\(foreign\s\+import\_s\+\)\?\([_a-z]\(\w\|\'\)*\)\_s\{-}\(::\|∷\)" contained
-  \ contains=purescriptImportKeyword,purescriptFunction,purescriptOperatorType
+syn match purescriptFunctionDeclStart "^\s*\(\(foreign\s\+import\|let\|where\)\_s\+\)\?\([_a-z]\(\w\|\'\)*\)\_s\{-}\(::\|∷\)" contained
+  \ contains=purescriptImportKeyword,purescriptWhere,purescriptLet,purescriptFunction,purescriptOperatorType
 syn keyword purescriptForall forall
 syn match purescriptForall "∀"
 
 " Keywords
 syn keyword purescriptConditional if then else
-syn keyword purescriptStatement do case of let in
+syn keyword purescriptStatement do case of in
+syn keyword purescriptLet let
 syn keyword purescriptWhere where
 syn match purescriptStructure "\<\(data\|newtype\|type\|class\|kind\)\>"
   \ nextgroup=purescriptType skipwhite
@@ -166,6 +167,7 @@ highlight def link purescriptBlockComment purescriptComment
 highlight def link purescriptStructure purescriptKeyword
 highlight def link purescriptKeyword Keyword
 highlight def link purescriptStatement Statement
+highlight def link purescriptLet Statement
 highlight def link purescriptOperator Operator
 highlight def link purescriptFunction Function
 highlight def link purescriptType Type

--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -63,7 +63,17 @@ syn match purescriptImportParams "hiding" contained
   \ nextgroup=purescriptModuleParams,purescriptImportParams skipwhite
 
 " Function declaration
-syn region purescriptFunctionDecl excludenl start="^\z(\s*\)\(\(foreign\s\+import\|let\|where\)\_s\+\)\?[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)" end="^\z1\=\S"me=s-1,re=s-1 keepend
+syn region purescriptFunctionDecl
+  \ excludenl start="^\z(\s*\)\(\(foreign\s\+import\)\_s\+\)\?[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
+  \ end="^\z1\=\S"me=s-1,re=s-1 keepend
+  \ contains=purescriptFunctionDeclStart,purescriptForall,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptDelimiter,@purescriptComment
+syn region purescriptFunctionDecl
+  \ excludenl start="^\z(\s*\)where\z(\s\+\)[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
+  \ end="^\(\z1\s\{5}\z2\)\=\S"me=s-1,re=s-1 keepend
+  \ contains=purescriptFunctionDeclStart,purescriptForall,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptDelimiter,@purescriptComment
+syn region purescriptFunctionDecl
+  \ excludenl start="^\z(\s*\)let\z(\s\+\)[_a-z]\(\w\|\'\)*\_s\{-}\(::\|∷\)"
+  \ end="^\(\z1\s\{3}\z2\)\=\S"me=s-1,re=s-1 keepend
   \ contains=purescriptFunctionDeclStart,purescriptForall,purescriptOperatorType,purescriptOperatorTypeSig,purescriptType,purescriptTypeVar,purescriptDelimiter,@purescriptComment
 syn match purescriptFunctionDeclStart "^\s*\(\(foreign\s\+import\|let\|where\)\_s\+\)\?\([_a-z]\(\w\|\'\)*\)\_s\{-}\(::\|∷\)" contained
   \ contains=purescriptImportKeyword,purescriptWhere,purescriptLet,purescriptFunction,purescriptOperatorType


### PR DESCRIPTION
Indent function declaration correctly (no indent)
```
f :: String -> String
f
```
but indent if it's a type declaration
```
f :: String
  -> String
```