### PR TITLE
Fix ftdetect sourcing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bugfixes:
   - docs did not reflect the code in using the `g:` prefix for indentation configuration [p73][]
   - some Unicode characters were not accounted for for the indentation [p84][]
   - highlight all bicameral scripts, not just Latin ones [p85][]
+  - remove unnecessary aug[roup] use in ftdetct [p91][]
 
 Other improvements:
   - rename default branch to `main`, clarify readme, add changelog [p73][]

--- a/ftdetect/purescript.vim
+++ b/ftdetect/purescript.vim
@@ -1,6 +1,4 @@
+" vint: -ProhibitAutocmdWithNoGroup
 scriptencoding utf-8
 
-augroup filetype_purescript
-	autocmd!
-	autocmd BufNewFile,BufRead *.purs setf purescript
-augroup END
+autocmd BufNewFile,BufRead *.purs setf purescript


### PR DESCRIPTION
## Overview

I've just fixed a small problem regarding to the use of `aug[roup]` in ftdetct.

It seems that that's already surrounded by an internal group by default, then if we define a new group for those `au[cmd]`(s) in ftdetct, that causes a problem at filetype detection in other subsequent plugins.

There are similar fixes also in other vim plugins:

* [fatih/vim-go#1645](https://github.com/fatih/vim-go/pull/1645) - Fix ftdetect
* [pangloss/vim-javascript#1183](https://github.com/pangloss/vim-javascript/pull/1183) - Fix ftdetect interfering with other plugins

And addition to that, there is an issue related to this topic, for Vint:

* [Vimjas/vint#264](https://github.com/Vimjas/vint/issues/264) - Must not use augroup in ftdetect/*.vim

## Problem

In my case, when I open a Racket file (`xxx.rkt`), the use of `aug[roup]` here causes an error like below (maybe **r**acket is the next to **p**urescript in my loaded vim plugins, in alphabetical order?):

```txt
Error detected while processing BufRead Autocommands for "*.rkt"..function RacketDetectHashLang[3]..FileType Autocommands for "*".
.function <SNR>21_LoadFTPlugin:
line    3:
E31: No such mapping
```

This is related to [wlangstroth/vim-racket](https://github.com/wlangstroth/vim-racket/blob/master/ftdetect/racket.vim#L23). The error message itself is unfortunately not so helpful, but the Vim doc of [:ftdetct](https://vimdoc.sourceforge.net/htmldoc/filetype.html#ftdetect) mentions like so:

> Note that there is no "augroup" command, this has already been done
> when sourcing your file. 

We usally need to surround `au[tocmd]s` with an `aug[roup]`, but likely don't need so in the `ftdetct` directory.

*UPDATED*
Apparently, it seems that the reason of the above error is that the use of `aug[roup]` here causes unexpected unloading of another plugin. In the case on my env (for vim-racket), [this part](https://github.com/wlangstroth/vim-racket/blob/2c7ec0f35a2ad1ca00305e5d67837bc1f1d4b6cc/ftplugin/racket.vim#L77-L82) (`b:undo_ftplugin`) is evaluated. 

## Changes

Thus, this pull request simply removes an unnecessary aug[roup] in ftdetct, and adds a comment to ignore Vint's rule `ProhibitAutocmdWithNoGroup` here.

I hope that makes sense!

**Checklist:**

- [x] Briefly described the change
- [ ] Opened an issue before investing a significant amount of work into changes
- [ ] Updated README.md with any new configuration options and behavior
- [x] Updated CHANGELOG.md with the proposed changes
- [ ] Ran `generate-doc.sh` to re-generate the documentation
