### PR TITLE
`--|` should be highlighted as a comment

### DIFF
--- a/syntax/purescript.vim
+++ b/syntax/purescript.vim
@@ -158,7 +158,7 @@ syn region purescriptString start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
 syn region purescriptMultilineString start=+'"'+ end=+'"'+ fold contains=@Spell
 
 " Comment
-syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$" contains=purescriptCommentTodo,@Spell
+syn match purescriptLineComment "---*\([^-!#$%&\*\+./<=>\?@\\^~].*\)\?$" contains=purescriptCommentTodo,@Spell
 syn region purescriptBlockComment start="{-" end="-}" fold
 	\ contains=purescriptBlockComment,@Spell
 syn cluster purescriptComment contains=purescriptLineComment,purescriptBlockComment,@Spell


### PR DESCRIPTION
**Checklist:**

`--|` was highlighted as an operator, but it is infact a valid comment. Since it's sometimes used for `doc`-comments it's nice to have it function.

- [x] Briefly described the change

I don't think these are relevant - but if it is deemed relevant I'm more than happy to fix it.

- [ ] Opened an issue before investing a significant amount of work into changes
- [ ] Updated README.md with any new configuration options and behavior
- [ ] Updated CHANGELOG.md with the proposed changes
- [ ] Ran `generate-doc.sh` to re-generate the documentation
